### PR TITLE
Integrate backend and frontend to start together

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ The frontend is implemented using React, providing the following components:
    npm start
    ```
 
+### Combined Start
+
+1. Install dependencies for both backend and frontend:
+   ```bash
+   npm install
+   ```
+
+2. Start both backend and frontend together:
+   ```bash
+   npm run dev
+   ```
+
 ## Usage
 
 1. Register a new user on the registration page.

--- a/backend/server.js
+++ b/backend/server.js
@@ -9,9 +9,9 @@ const authRoutes = require('./routes/auth');
 const fileRoutes = require('./routes/files');
 
 const app = express();
-const port = process.env.PORT || 3000;
+const port = process.env.PORT || 5000;
 
-mongoose.connect('mongodb://localhost:27017/cdn', {
+mongoose.connect('mongodb+srv://<username>:<password>@cluster0.mongodb.net/cdn?retryWrites=true&w=majority', {
   useNewUrlParser: true,
   useUnifiedTopology: true,
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -7,6 +7,7 @@ const User = require('./models/User');
 const File = require('./models/File');
 const authRoutes = require('./routes/auth');
 const fileRoutes = require('./routes/files');
+const path = require('path');
 
 const app = express();
 const port = process.env.PORT || 5000;
@@ -19,6 +20,12 @@ mongoose.connect('mongodb+srv://<username>:<password>@cluster0.mongodb.net/cdn?r
 app.use(express.json());
 app.use('/auth', authRoutes);
 app.use('/files', fileRoutes);
+
+app.use(express.static(path.join(__dirname, 'frontend/build')));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'frontend/build', 'index.html'));
+});
 
 app.listen(port, () => {
   console.log(`Server is running on port ${port}`);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@testing-library/jest-dom": "^5.11.4",
+    "@testing-library/react": "^11.1.0",
+    "@testing-library/user-event": "^12.1.10",
+    "axios": "^0.21.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-router-dom": "^5.2.0",
+    "react-scripts": "4.0.3",
+    "web-vitals": "^1.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "proxy": "http://localhost:5000"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cdn-system",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "concurrently \"npm run server\" \"npm run client\"",
+    "server": "cd backend && npm start",
+    "client": "cd frontend && npm start"
+  },
+  "dependencies": {
+    "concurrently": "^6.2.1"
+  }
+}


### PR DESCRIPTION
Combine backend and frontend start process into a single command.

* **Backend Changes:**
  - Change the port in `backend/server.js` to 5000.
  - Update the MongoDB connection string to use a remote connection.

* **Frontend Changes:**
  - Add a proxy to the backend in `frontend/package.json`.

* **Combined Start:**
  - Add a `package.json` file to run both backend and frontend together using `concurrently`.
  - Update `README.md` with new start instructions.

